### PR TITLE
Rewrite session handling to allow datagram sockets.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,28 +28,67 @@ The `kitty-convert-dump.py` also takes an optional `--no-copy-env` argument. Cop
 
 ### Automated
 
-#### Setup
+#### Kitty Config Setup
+
 
 You will first need to be sure kitty is configured to allow remote control access.  This can only be done in the `kitty.conf` by setting the `allow_remote_control_access` option, and it needs to be set to one of: `socket-only`, `socket`, or `yes`.  
 
-You will also need to configure kitty to automatically create socket files in a known location.  While this can be done with the `--listen-on` option, it really needs to be set as the `listen_on` option in the `kitty.conf` for it to be useful.  
-You'll need to pick a folder to store the communication sockets for remote control of kitty instances in, which I've set to `${HOME}/.cache/kitty/sessions/` in this example.  The folder must already exist or kitty will refuse to open with this setting.
+You will also need to configure kitty to create sockets with a known name/location. The `listen_on` directive in the kitty.conf file is used for this. The automation tools only support unix sockets, so these always need to have the protocol prefix `unix:`.  
+You can create socket files in a known folder location by setting the path and name, making sure to include the kitty-placeholder `{kitty_pid}` somewhere in the file name. However you'll want this to be a non-persistent location or you'll slowly accumulate broken socket files whenever you reboot without all kitty instances being shut down.  
+You can also create datagram sockets instead (localhost-only sockets). These are created by setting the name starting with `@`, and must have a globally unique name that can be differentiated from the other datagram sockets on the system. Usually just including `kitty` in the name somewhere will ensure that uniqueness though.
+
+Examples:
 ```
+# using socket files (warning, this location will result in slowly accumulating broken socket files)
 listen_on unix:${HOME}/.cache/kitty/sessions/{kitty_pid}.sock
+# using datagram sockets
+listen_on unix:@kitty-{kitty_pid}.sock
 ```
-The `{kitty_pid}` here is a placeholder the kitty config uses that will get replaced with the pid of the kitty instance.  Optionally, if
-you ensure the variable is always set, you can make use of the `KITTY_SESSION_SOCKS_PATH` environment variable here instead, which also allows the scripts mentioned below to match exactly:
-```
-listen_on unix:${KITTY_SESSION_SOCKS_PATH}/{kitty_pid}.sock
-```
+
+WARNING: The `listen_on` settting must refer to an existing directory when using socket files. It will not create the folder for you.
+
+#### Tool Setup
+
+The tools rely on knowing the directory to save the sessions into, and the pattern used to name the sockets (datagram or file).  
+Either modify the default vaules at the top of the common.incl file, or set them in the environment whenever calling the script.
+
+`KITTY_SESSION_SOCK_PATTERN`: Should match the `listen_on` kitty config setting, without the `unix:` protocol prefix.  
+`KITTY_SESSION_SAVE_DIR`: The directory where the saved session files are stored.  This will be created if it doesn't exist. It should be a dedicated location since it will be removed and replaced whenever an update to the saved sessions occurs.
 
 #### Tools
 
-The `kitty-save-session-all.sh`, `kitty-save-session-restore-all.sh`, and `kitty-save-session-remove-inactive.sh` scripts can now be used by either modifying the default path for `KITTY_SESSION_SOCKS_PATH` and `KITTY_SESSION_SAVE_DIR` in them, or by ensuring those environment variables are set whenever the scripts are used (e.g. in your `.profile`).
+Three scripts are provided for direct use: `kitty-save-session-all.sh`, `kitty-save-session-restore-all.sh`, and `kitty-save-session-remove-inactive.sh`.
+These scripts all rely on the configuration variables remaining the same between every call to them, but provide straighforward functionality as indicated by their names.
 
-The `kitty-save-session-all.sh` just loops thru the list of `*.sock` socket files kitty has created for enabling remote control for the instances, queries each instance state from them, converts the output to a `*.kitty` saved session file, and cleans up any old saved session files that don't match currently running instances.  If there are no instances running however, it will not do any cleanup of saved session files.
-Additionally, this script supports an optional `KITTY_SESSION_SAVE_OPTS` variable that can be set to any space-separated list of arguments that should be passed to the python script performing the conversion to the kitty session syntax.  See the help output of it for hte available options.
 
-The `kitty-save-session-restore-all.sh` just loops thru the list of `*.kitty` saved session files, and runs a new instance of kitty for each as a detached session (runs independent of the calling shell) with a starting point matching the saved session state.
+The `kitty-save-session-all.sh` just loops thru the list of sockets kitty has created, queries each instance state from them, converts the output to a saved session file into a temp folder, and then replaces the `KITTY_SESSION_SAVE_DIR` with the temp folder.  If there are no kitty instances running however, it will not do any cleanup of saved session files.
+Additionally, this script supports an optional `KITTY_SESSION_SAVE_OPTS` variable that can be set to any space-separated list of arguments that should be passed to the python script performing the conversion to the kitty session syntax.  See the help output of it for the available options.
+Errors saving the state of kitty sessions are handled uniquely for socket files vs datagram sockets. Socket files may be in a persistent location that results in an increasing number of broken socket files from kitty sessions that weren't terminated cleanly. When socket files are detected as the form being used, any successful saving of a session is considered an overall success, and broken sockets will generate error output but won't cause the overall call to fail. Datagram sockets however will fail on the first failed attempted read from the socket.  
 
-The `kitty-save-session-remove-inactive.sh` script will remove any saved session files that don't match currently running instances.  This is useful for cleaning up old saved session files you no longer want to restore, even when there are no instances currently running.
+The `kitty-save-session-restore-all.sh` just loops thru the list of saved session files, and runs a new instance of kitty for each. The kitty sessions are run asdetached sessions, which are independent of the calling shell the script was executed in.  This will "restore" your sessions to the extent possible with kitty. Some setting do get unavoidably inherited from the calling shell, most notably the `SHLVL` variable, so restored sessions will usually appear to be at a deeper level of shell nesting than the originals.  Also note that the PIDs of the new sessions cannot match the ones from the original sessions, so it's inadvisable to immediately run `kitty-save-session-remove-inactive.sh` since all current saved sessions will appear unmatched by the restored instances.
+
+The `kitty-save-session-remove-inactive.sh` script will remove any saved session files that don't match currently running kitty instances.  This is useful for cleaning up old saved session files you no longer want to restore, even when there are no instances currently running. Matching is based on PID, which restored sessions cannot match, so it's advisable to instead use `kitty-save-session-all.sh`, which implicitly cleans up any inactive saved sessions as part of generating the new ones, after a `kitty-save-session-restore-all.sh`.
+
+#### Systemd Integration
+
+If you want to automatically save your kitty sessions against unexpected reboots, systemd can be used to create user unit files to automate the saving.  Example files can be found in the `systemd/` folder.  They will need to be customized, put in `~/.config/systemd/user/`, and enabled.  
+
+Customization needed:
+
+In `kitty-session-save.timer`, set the frequency to update the saved sessions.  
+
+In `kitty-save-session.service`, modify the `ExecStart` to specify the absolute path to the `kitty-save-session-all.sh` script, and set `KITTY_SESSION_SAVE_DIR`, `KITTY_SESSION_SOCK_PATTERN`, and `KITTY_SESSION_SAVE_OPTS` environment variables to match your configuration, or you can configure the environment variables in your `.profile` or similar file and remove the definitions from this file, or you can directly modify the `kitty-save-session-common.incl`.  
+Optionally you can also enable notifications when kitty fails to save sessions by uncommenting the `OnFailure` line, then installing and modifying the `kitty-save-session-notify-failed.service` file as well. 
+
+The `kitty-save-session-notify-failed.service` is optional and only used if you uncommented the `OnFailure` line in the `kitty-save-session.service` file.  This uses the `noti` tool, which you would need to install separately, to send notifications (default is a desktop notification).  You must modify the `ExecStart` line to point to the absolute path where you've installed the `noti` tool, and can further modify what you want that notification to be. This service unit is only exected when saving sessions fails.
+
+## Troubleshooting
+
+### My Saved Session Files Exist But Sessions Won't Restore
+
+Assuming the files pointed to by the `--session=` option passed to `kitty` when calling `kitty-save-session-restore-all.sh` actually exist, they may be failing to parse due to particularly complex environment variables. The kitty session file format isn't very robust, and doens't allow anything more than relatively simplisitc environment variables to be included. The `kitty-convert-dump.py` is unable to handle all possible complexity, and merely quotes the environment variables in the kitty session file it generates.  
+
+Examine your saved session file to see if you have quotes within values or multi-line values being passed as `--env` arguments to `launch` commands.  
+Unfortunately with the `--detach` option necessary for the kitty restore, it's not possible to check whether kitty successfully restored, or if it encountered an error loading the session file so it silently fails to restore the os window.
+
+To avoid this issue, the only solution is to disable the inclusion of the environment in your saved sessions.  This can be done by setting the `KITTY_SESSION_SAVE_OPTS` environment variable to `--no-copy-env`, which will disable environment copying as part of session saving.

--- a/kitty-save-session-common.incl
+++ b/kitty-save-session-common.incl
@@ -1,0 +1,176 @@
+# shellcheck shell=bash
+# vim: ts=4:sw=4:et:syntax=bash
+
+# This is a bash include file for the kitty-save-session-*.sh scripts that holds common functions/definitions.
+# Global Environment Variables set/used:
+#  KITTY_SESSION_SOCK_PATTERN - The pattern that includes '{kitty_pid}' that was used in the kitty 'listen_on' config directive, without the 'unix:' prefix.
+#                               If this starts with '@' it will look for datagram sockets instead of sockets in a folder, and KITTY_SESSION_SOCKS_PATH is
+#                               ignored. The '{kitty_pid}' placeholder must be part of the file name, not any directory path.
+#                               If using '@', be sure the naming is unique so it can be differented among all system listening sockets!
+#                               Default=${HOME}/.cache/kitty/sessions/{kitty_pid}.sock
+#  KITTY_SESSION_SAVE_DIR - The folder to save the *.kitty session files in. Will be deleted and replaced every time the sessions are saved.
+#  KITTY_SESSION_SOCKS_PATH - a deprecated option for setting a folder to find sockets named '{kitty_pid}.sock' in. Only used if KITTY_SESSION_SOCK_PATTERN
+#                             is unset. Defaults to ${HOME}/.cache/kitty/sessions
+
+# deprecated variable only used if KITTY_SESSION_SOCK_PATTERN is unset
+readonly KITTY_SESSION_SOCKS_PATH="${KITTY_SESSION_SOCKS_PATH:-${HOME}/.cache/kitty/sessions}"
+
+# set a default that matches prior legacy behavior, including use of the deprecated KITTY_SESSION_SOCKS_PATH variable
+if [[ -z ${KITTY_SESSION_SOCK_PATTERN} ]]; then
+    KITTY_SESSION_SOCK_PATTERN="${KITTY_SESSION_SOCKS_PATH}/{kitty_pid}.sock"
+fi
+readonly KITTY_SESSION_SOCK_PATTERN
+
+if [[ -z ${KITTY_SESSION_SAVE_DIR} ]]; then
+    # if the user didn't set a save directory, use the default one
+    KITTY_SESSION_SAVE_DIR="${HOME}/.cache/kitty/saved-sessions"
+fi
+readonly KITTY_SESSION_SAVE_DIR
+
+#------------------------------------------------
+
+quit() {
+    (( $# == 0 )) || echo "$@"
+    exit 0
+}
+export -f quit
+
+die() {
+    (( $# == 0 )) || echo >&2 "ERROR:" "$@"
+    exit 1
+}
+export -f die
+
+is_dgram() {
+    # check if the socket name starts with '@'
+    [[ ${KITTY_SESSION_SOCK_PATTERN} =~ ^@ ]]
+}
+export -f is_dgram
+
+# Create a perl-format regex that will mach the file name of the socket specified by KITTY_SESSION_SOCK_PATTERN.
+# The first match group in the regex will always be the pid portion of the socket name.
+# When KITTY_SESSION_SOCK_PATTERN starts with '@', so will the pattern. When it doesn't, only the file name portion
+# of the socket will be matched (not the path to it).
+# Args: None
+# Globals:
+#  KITTY_SESSION_SOCK_PATTERN - The pattern that includes '{kitty_pid}' as part of the name, matching the 'listen_on' config directiive from the
+#                               kitty.conf file (without the 'unix:' prefix).  If it starts with a '@' it is treated as a datagram socket. If it
+#                               doesn't, then it must be an absolute path to a folder with sockets in it.
+get_socket_pid_regex() {
+    if is_dgram; then
+        # Creates a perl regex where the first match group is the pid portion of the dgram socket name.
+        echo "${KITTY_SESSION_SOCK_PATTERN}" | sed -E -e 's|\{kitty_pid\}|\\E(\\d+)\\Q|g' -e 's|^|^\\Q|g' -e 's|$|\\E$|g'
+    else
+        # construct a regex that will match the pid portion of the socket file name in the folder.
+        # Creates a perl regex where the first  match group is the pid portion.
+        basename "${KITTY_SESSION_SOCK_PATTERN}" | sed -E -e 's|\{kitty_pid\}|\\E(\\d+)\\Q|g' -e 's|^|^\\Q|g' -e 's|$|\\E$|g'
+    fi
+}
+export -f get_socket_pid_regex
+
+# Gets the list of sockets for kitty sessions. If they're datagram sockets, they will start with '@'. If they're socket files,
+# they will be the fully pathed names. Does this by either parsing listening unix sockets from 'ss' or 'netstat', or by searching
+# the socket directory for the files matching the pattern and returning the fully pathed socket file names.
+# Args:
+#  1: Name of the global array variable to add the socket file names to.
+# Globals:
+#  KITTY_SESSION_SOCK_PATTERN - The pattern that includes '{kitty_pid}' as part of the name, matching the 'listen_on' config directiive from the
+#                               kitty.conf file (without the 'unix:' prefix).  If it starts with a '@' it is treated as a datagram socket. If it
+#                               doesn't, then it must be an absolute path to a folder with sockets in it.
+get_active_sockets() {
+    local ret_array_var
+    # bind our local variable name to the global variable passed by name
+    declare -n ret_array_var="$1"
+
+    # gives a perl-format regex that will match against either the datagram socket (with leading '@'), or the socket file name (no path)
+    local socket_regex
+    socket_regex="$(get_socket_pid_regex)"
+
+    if is_dgram; then
+        if command -v ss &>/dev/null; then
+            # use 'ss' to look for the datagram sockets
+            readarray -O ${#ret_array_var[@]} -t ret_array_var < <(ss --listening --no-header --unix | awk '{print $5}' | grep -P "${socket_regex}")
+        elif command -v netstat &>/dev/null; then
+            # netstat uses spaces as aligned-column separators, but also within the flags column values. So rely on the Path
+            # column being last and use '$NF'.
+            readarray -O ${#ret_array_var[@]} -t ret_array_var < <(netstat --listening --unix | awk '{print $NF}' | grep -P "${socket_regex}")
+        else
+            echo >&2 "Cannot find 'ss' or 'netstat' command, no available way to search listening datagram sockets"
+        fi
+    else
+        local socket_dir
+        # Folder to find your active kitty sessions in.
+        socket_dir="$(dirname "${KITTY_SESSION_SOCK_PATTERN}")"
+
+        # if the directory doesn't exist, we won't find anything in it so don't bother searching it
+        if [[ -d ${socket_dir} ]]; then
+            # find doesn't support perl regex, with -regextype, so list all the files and then us grep to filter them.
+            # Just be sure we are only printing the file names from find or the regex won't work as expected
+            readarray -O ${#ret_array_var[@]} -t ret_array_var < <(find "$socket_dir" -mindepth 1 -maxdepth 1 -printf '%P\n' | grep -P "${socket_regex}")
+            # re-attach the folder names to the front of the socket names
+            ret_array_var=("${ret_array_var[@]/#/${socket_dir}/}")
+        fi
+    fi
+}
+export -f get_active_sockets
+
+# Given a list of socket names, prints the list of pids extracted from them. The order of the output pids numbers will match 
+# the order of the socket names provided.
+# Args:
+#  1+: The list of socket names to extract the pid numbers from. Socket files may optionally include the folder path portion, though
+#      it must exactly match the path as listed in the KITTY_SESSION_SOCK_PATTERN variable. Datagrams must start with '@'.
+#      Only names that match the KITTY_SESSION_SOCK_PATTERN shoudl be passed, anythign not matching will be passed thru unchanged.
+# Globals:
+#  KITTY_SESSION_SOCK_PATTERN - The pattern that includes '{kitty_pid}' as part of the name, matching the 'listen_on' config directiive from the
+#                               kitty.conf file (without the 'unix:' prefix).  If it starts with a '@' it is treated as a datagram socket. If it
+#                               doesn't, then it must be an absolute path to a folder with sockets in it.
+get_pids_from_socket_names() {
+    local socket_pid_regex
+    socket_pid_regex=$(get_socket_pid_regex)
+
+    local args=("$@")
+    if ! is_dgram; then
+        # get the shared directory name from the socket pattern
+        local socket_dir
+        socket_dir="$(dirname "${KITTY_SESSION_SOCK_PATTERN}")"
+        # strip the socket directory from the front of the socket names since our regex doesn't match that part
+        args=("${args##"${socket_dir}/"}")
+    fi
+    # perl -pe interprets '@' symbols as an array name. There's no way to quote the body of a substitution or regex to
+    # prevent this, so we have to use "@{['@']}" to get the literal '@' symbol in the regex string perl is parsing.
+    # Using single-quotes there isn't very friendly though, so we can use the perl 'q()'' function instead.
+    # So substitute all occences of '@' in the regex with '@{[q(@)]}' to get a literal '@' symbol in the regex.
+    socket_pid_regex="${socket_pid_regex/@/@{[q(@)]\}}"
+
+    # Print what was passed, one per line, and feed it to the perl command.
+    # Use a perl substitution to extract the first match group from the socket name
+    printf '%s\n' "$@" | perl -pe "s|${socket_pid_regex}|\$1|g"
+}
+export -f get_pids_from_socket_names
+
+# Gets the list of fully-pathed saved session files in the KITTY_SESSION_SAVE_DIR directory.
+# The files are named after the kitty pid they were saved from.
+# Args: None
+# Globals:
+#  KITTY_SESSION_SAVE_DIR - The folder the *.kitty session files are saved into
+get_saved_sessions() {
+    find "$KITTY_SESSION_SAVE_DIR" -mindepth 1 -maxdepth 1 -name '*.kitty'
+}
+export -f get_saved_sessions
+
+# Gets the unpathed name of the saved session file from the pid of the kitty session it saves.
+# Args:
+#  1: The pid of the kitty session
+get_saved_session_file_name_from_pid() {
+    echo -n "${1}.kitty"
+}
+export -f get_saved_session_file_name_from_pid
+
+# Gets the pid a saved session file was saved for from the file name
+# of the saved session file.
+# Args:
+#  1: The name of the saved session file. May be fully pathed, or not.
+get_pid_from_saved_session() {
+    basename -s .kitty "$1"
+}
+export -f get_pid_from_saved_session

--- a/kitty-save-session-remove-inactive.sh
+++ b/kitty-save-session-remove-inactive.sh
@@ -1,39 +1,50 @@
 #!/bin/bash
 # Global Environment Variables:
-#  KITTY_SESSION_SOCKS_PATH - The folder to find the kitty remote control *.sock files in.
+#  KITTY_SESSION_SOCK_PATTERN - The pattern that includes '{kitty_pid}' that was used in the kitty 'listen_on' config directive, without the 'unix:' prefix.
+#                               If this starts with '@' it will look for datagram sockets instead of sockets in a folder, and KITTY_SESSION_SOCKS_PATH is
+#                               ignored. The '{kitty_pid}' placeholder must be part of the file name, not any directory path.
+#                               If using '@', be sure the naming is unique so it can be differented among all system listening sockets!
+#                               Default=${HOME}/.cache/kitty/sessions/{kitty_pid}.sock
 #  KITTY_SESSION_SAVE_DIR - The folder to save the *.kitty session files in.
-
+#  KITTY_SESSION_SAVE_OPTS - optional. If set it must be space separteed options that will be passed to the kitty-convert-dump.py script
+#                            unquoted.
+#  KITTY_SESSION_SOCKS_PATH - a deprecated option for setting a folder to find sockets named '{kitty_pid}.sock' in. Only used if KITTY_SESSION_SOCK_PATTERN
+#                             is unset. Defaults to ${HOME}/.cache/kitty/sessions
 set -o pipefail # make piped commands return exit codes like you'd expect
 
-# this must match kitty.conf's 'listen_on unix:${KITTY_SESSION_SOCKS_PATH}/{kitty_pid}.sock', 
-# and you must also have 'allow_remote_control' set to 'on', 'socket', or 'socket-only'
-my_active_sessions_folder=${KITTY_SESSION_SOCKS_PATH:-${HOME}/.cache/kitty/sessions}
+SCRIPT_DIR=$(dirname "$0")
+readonly SCRIPT_DIR
 
-mkdir -p "$my_active_sessions_folder"
+#shellcheck disable=SC1091 # shellcheck can't follow includes
+source "${SCRIPT_DIR}/kitty-save-session-common.incl" || { echo >&2 "Cannot source common.incl in \$(dirname $0)=${SCRIPT_DIR}"; exit 1; }
 
-# Folder to save your sessions in. Not recommended to be the same as my_active_sessions_folder
-my_saved_sessions_folder=${KITTY_SESSION_SAVE_DIR:-${HOME}/.cache/kitty/saved-sessions}
+#------------------------------------------------
 
-mkdir -p "$my_saved_sessions_folder"
+# Make sure the save directory exists, even if we don't end up doing anything because it's empty
+mkdir -p "$KITTY_SESSION_SAVE_DIR"
 
-active_session_files=()
-readarray -t active_session_files < <(find "$my_active_sessions_folder" -mindepth 1 -name '*.sock')
+active_session_sockets=()
+# get the socket list
+get_active_sockets active_session_sockets
+# get the list of active pids from the socket names
+active_session_pids=()
+if (( ${#active_session_sockets[@]} > 0 )); then
+    readarray -t active_session_pids < <(get_pids_from_socket_names "${active_session_sockets[@]}")
+fi
 
 saved_session_file=()
-readarray -t saved_session_file < <(find "$my_saved_sessions_folder" -mindepth 1 -name '*.kitty')
+readarray -t saved_session_file < <(get_saved_sessions)
 
 # this is such a common case, watch for it and skip the searching for matches
-if (( ${#active_session_files[@]} > 0 )); then
+if (( ${#active_session_pids[@]} > 0 )); then
     # Remove files from the saved_session_file list that still have active sessions.
     for saved_idx in "${!saved_session_file[@]}"; do
-        for active in "${active_session_files[@]}"; do
+        for active_pid in "${active_session_pids[@]}"; do
             # strips the .kitty extension and path from the file name
-            saved_pid=$(basename -s .kitty "${saved_session_file[$saved_idx]}")
-            # strips the .sock extension and path from the file name
-            active_pid=$(basename -s .sock "$active")
+            saved_pid=$(get_pid_from_saved_session "${saved_session_file[$saved_idx]}")
             if [[ "$saved_pid" == "$active_pid" ]]; then
                 # remove it from our list, it matches an active pid
-                unset saved_session_file[$saved_idx]
+                unset "saved_session_file[$saved_idx]"
                 # found a match, stop looking for more active sessions to match this saved session pid
                 break
             fi

--- a/kitty-save-session-restore-all.sh
+++ b/kitty-save-session-restore-all.sh
@@ -4,13 +4,17 @@
 
 set -o pipefail
 
-# This must match KITTY_SESSION_SAVE_DIR when kitty-save-session-all.sh was called
-my_saved_sessions_folder=${KITTY_SESSION_SAVE_DIR:-${HOME}/.cache/kitty/saved-sessions}
+SCRIPT_DIR=$(dirname "$0")
+readonly SCRIPT_DIR
 
-mkdir -p "$my_saved_sessions_folder"
+#shellcheck disable=SC1091 # shellcheck can't follow includes
+source "${SCRIPT_DIR}/kitty-save-session-common.incl" || { echo >&2 "Cannot source common.incl in \$(dirname $0)=${SCRIPT_DIR}"; exit 1; }
+
+# Make sure the save directory exists, even if we don't end up doing anything because it's empty
+mkdir -p "$KITTY_SESSION_SAVE_DIR"
 
 saved_session_file=()
-readarray -t saved_session_file < <(find "$my_saved_sessions_folder" -mindepth 1 -name '*.kitty')
+readarray -t saved_session_file < <(get_saved_sessions)
 
 for saved in "${saved_session_file[@]}"; do
     # --detach causes it to run in the background, but completely detached from this calling session,

--- a/systemd/kitty-save-session-failure-notify.service
+++ b/systemd/kitty-save-session-failure-notify.service
@@ -1,0 +1,12 @@
+# This file is optional, and only used if the OnFailure= line is uncommented in kitty-save-session.service.
+[Service]
+# Modify the tool used, message, or other details of how to notify that a failure occurred.
+ExecStart={absolute path to the tool}/noti -t 'Kitty Session Save Failed' -m 'Systemd service unit kitty-save-session.service failed. See journalctl --user -xu kitty-save-session.se>
+StandardError=journal
+StandardOutput=journal
+SyslogIdentifier=kitty-save-session-failure-notify
+Type=oneshot
+
+[Unit]
+Description=Notify on failure of kitty-save-session
+PartOf=kitty-save-session.service

--- a/systemd/kitty-save-session.service
+++ b/systemd/kitty-save-session.service
@@ -1,0 +1,19 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+Environment=KITTY_SESSION_SOCK_PATTERN={put your listen_on pattern here}
+Environment=KITTY_SESSION_SAVE_DIR={put the absolute path to your save directory here}
+Environment=KITTY_SESSION_SAVE_OPTS=
+ExecStart={absolute path your your script here}/kitty-save-session-all.sh
+# Optional. Uncomment this if you have setup the failure notification service as well
+#OnFailure=kitty-save-session-failure-notify.service
+StandardError=journal
+StandardOutput=journal
+SyslogIdentifier=kitty-save-session
+Type=oneshot
+
+[Unit]
+After=graphical-session.target
+Description=Save Kitty terminal sessions
+PartOf=graphical-session.target

--- a/systemd/kitty-save-session.timer
+++ b/systemd/kitty-save-session.timer
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+# How long to wait the very first time the timer unit is started
+OnActiveSec=2m
+# do not set < 1 min
+OnUnitActiveSec={your frequency here, e.g. 5m }
+
+[Unit]
+Description=Timer for saving Kitty terminal sessions


### PR DESCRIPTION
# Description

Eliminate the assumption of kitty control sockets being socket files instead of optionally datagram sockets, and eliminate the assumptions about the socket naming.  

Instead use a `KITTY_SESSION_SOCK_PATTERN` environment variable that just needs to be set to the kitty `listen_on` config value (without the `unix:`) prefix, and detect whether it's a socket file in a folder, or a datagram socket from that.  

Still retain backwards compatibility with the prior environment variables, and default the `KITTY_SESSION_SOCK_PATTERN` to a value that uses the now-deprecated `KITTY_SESSION_SOCKS_PATH` (which also retains it's prior default value) when it's not otherwise set.

Update the README, but also expand it to reference some new example systemd unit files that can be used to implement automatic session saving as user systemd units.

# Comments

Some of the assumptions about formats and parsing were moved into utility functions that are now in a `kitty-save-session-common.incl` file that needs to be kept with the other scripts.  It's not ideal that they all need to be kept together, but the logic is now complex enough that copy-pasting between files is non-trivial.

I also specifically mentioned in the README about the potential pitfalls with the environment parsing.  The previously added `--no-copy-env` flag to the python script is now mentioned explicitly, along with how to use it as part of automation, in case others run into problems like I occasionally do where my environment is too complex to be reasonably encoded into the session file.  Maybe some day that can be detected automatically and the environment excluded from the session file translation if it can't be encoded properly.